### PR TITLE
Enhance question service

### DIFF
--- a/client/src/components/CodeEditor.jsx
+++ b/client/src/components/CodeEditor.jsx
@@ -33,6 +33,45 @@ import { MonacoBinding } from "y-monaco";
 import { PropTypes } from "prop-types";
 import { createSubmissionStore } from "../stores/createSubmissionStore";
 import { getSubmissionResultStore } from "../stores/getSubmissionResultStore";
+import { useModalComponentStore } from "../contextProviders/modalContext";
+
+
+
+const nextQuestionModalTitle = "Accept Request?";
+
+const nextQuestionModalBody = "Your partner has requested to move on to the next question. Do you agree?";
+
+const NextQuestionModalFooter = observer(() => {
+
+  const handleCancel = (e) => {
+    e.preventDefault();
+
+    // matchingFormStore.sendMatchCancelRequest();
+  };
+
+  return (
+    <>
+      <Button
+        colorScheme="red"
+        mr={3}
+        onClick={handleCancel}
+      >
+        Decline
+      </Button>
+
+      <Button
+      colorScheme="green"
+      mr={3}
+      type="submit"
+    >
+      Accept
+    </Button>
+
+    </>
+
+  );
+});
+
 
 /**
  * `language` prop changes when PEER changes language
@@ -54,6 +93,7 @@ export const CodeEditor = observer(
     const resultStore = getSubmissionResultStore;
     const [isRunLoading, setRunLoading] = useState(false);
     const [isPressed, setPressed] = useState(false);
+    const modalComponentStore = useModalComponentStore();
 
     useEffect(() => {
       // TODO: Debug this -- why doesn't monaco initialise with the template code?
@@ -168,6 +208,18 @@ export const CodeEditor = observer(
       }
     }, []);
 
+    const initiateNextQuestionRequest = () => {
+      modalComponentStore.openModal(
+        nextQuestionModalTitle,
+        nextQuestionModalBody,
+        <NextQuestionModalFooter />,
+        (e) => {
+
+        }
+      );
+
+    }
+
     const resetCode = () => {
       if (
         confirm(
@@ -278,7 +330,11 @@ export const CodeEditor = observer(
               bg="gray.300"
               color="black"
             >
-              <IconButton icon={<ArrowForwardIcon />} variant={"outline"} />
+              <IconButton 
+                icon={<ArrowForwardIcon />} 
+                variant={"outline"} 
+                onClick={initiateNextQuestionRequest}
+              />
             </Tooltip>
             <Tooltip label="Open Chat" hasArrow bg="gray.300" color="black">
               <IconButton icon={<ChatIcon />} variant={"outline"} />

--- a/client/src/components/CodeEditor.jsx
+++ b/client/src/components/CodeEditor.jsx
@@ -40,7 +40,7 @@ import { viewSessionStore } from "../stores/viewSessionStore";
  * `onLanguageChange` is a callback function called when USER changes language
  */
 export const CodeEditor = observer(
-  ({ questionTitle, roomId, language, onLanguageChange }) => {
+  ({ questionTitle, roomId, language, onLanguageChange, isGetNextQuestionLoading }) => {
     const WS_SERVER_URL = "ws://localhost:8002";
     const editorRef = useRef(null);
     const [userLanguage, setUserLanguage] = useState(language);
@@ -172,9 +172,7 @@ export const CodeEditor = observer(
 
     const initiateNextQuestionRequest = () => {
       viewSessionStore.initChangeQuestion();
-
-
-
+      viewSessionStore.setIsGetQuestionLoading(true);
     }
 
     const resetCode = () => {
@@ -289,6 +287,7 @@ export const CodeEditor = observer(
             >
               <IconButton 
                 icon={<ArrowForwardIcon />} 
+                isLoading={isGetNextQuestionLoading}
                 variant={"outline"} 
                 onClick={initiateNextQuestionRequest}
               />

--- a/client/src/components/CodeEditor.jsx
+++ b/client/src/components/CodeEditor.jsx
@@ -33,45 +33,7 @@ import { MonacoBinding } from "y-monaco";
 import { PropTypes } from "prop-types";
 import { createSubmissionStore } from "../stores/createSubmissionStore";
 import { getSubmissionResultStore } from "../stores/getSubmissionResultStore";
-import { useModalComponentStore } from "../contextProviders/modalContext";
-
-
-
-const nextQuestionModalTitle = "Accept Request?";
-
-const nextQuestionModalBody = "Your partner has requested to move on to the next question. Do you agree?";
-
-const NextQuestionModalFooter = observer(() => {
-
-  const handleCancel = (e) => {
-    e.preventDefault();
-
-    // matchingFormStore.sendMatchCancelRequest();
-  };
-
-  return (
-    <>
-      <Button
-        colorScheme="red"
-        mr={3}
-        onClick={handleCancel}
-      >
-        Decline
-      </Button>
-
-      <Button
-      colorScheme="green"
-      mr={3}
-      type="submit"
-    >
-      Accept
-    </Button>
-
-    </>
-
-  );
-});
-
+import { viewSessionStore } from "../stores/viewSessionStore";
 
 /**
  * `language` prop changes when PEER changes language
@@ -93,7 +55,7 @@ export const CodeEditor = observer(
     const resultStore = getSubmissionResultStore;
     const [isRunLoading, setRunLoading] = useState(false);
     const [isPressed, setPressed] = useState(false);
-    const modalComponentStore = useModalComponentStore();
+
 
     useEffect(() => {
       // TODO: Debug this -- why doesn't monaco initialise with the template code?
@@ -209,14 +171,9 @@ export const CodeEditor = observer(
     }, []);
 
     const initiateNextQuestionRequest = () => {
-      modalComponentStore.openModal(
-        nextQuestionModalTitle,
-        nextQuestionModalBody,
-        <NextQuestionModalFooter />,
-        (e) => {
+      viewSessionStore.initChangeQuestion();
 
-        }
-      );
+
 
     }
 

--- a/client/src/pages/ViewSession.jsx
+++ b/client/src/pages/ViewSession.jsx
@@ -114,7 +114,9 @@ export const ViewSession = observer(() => {
     
     const handleCancel = (e) => {
       e.preventDefault();
-      // matchingFormStore.sendMatchCancelRequest();
+
+      store.rejectChangeQuestion();
+      modalComponentStore.closeModal();
     };
 
     return (
@@ -157,7 +159,13 @@ export const ViewSession = observer(() => {
   }
 
   const rejectRequestCallback = () => {
-
+    store.setIsGetQuestionLoading(false);
+    toast({
+      title: `Your partner has rejected your request, try again later.`,
+      status: "warning",
+      duration: 8000,
+      isClosable: true,
+    });
   }
 
   const handleLeaveSession = async () => {
@@ -231,6 +239,7 @@ export const ViewSession = observer(() => {
                 roomId={state.roomId}
                 language={state.language}
                 onLanguageChange={(newLang) => store.setLanguage(newLang)}
+                isGetNextQuestionLoading = {state.isGetNextQuestionLoading}
               />
             )}{" "}
           </Stack>

--- a/client/src/pages/ViewSession.jsx
+++ b/client/src/pages/ViewSession.jsx
@@ -93,21 +93,26 @@ export const ViewSession = observer(() => {
     };
   }, []);
 
-  // This callback only runs upon a successful DELETE from the Sessions collection
-  const leaveSessionCallback = async() => {
-    //Save Attempt To History
+  const createAttempt = async () => {
     const userData = localStorage.getItem("user");
     const userObject = JSON.parse(userData);
     const uid = userObject.uid;
     const attempt = {
       currentUserId: uid,
-      title: location.state.title,
-      description: location.state.description,
-      category: location.state.category,
-      complexity: location.state.complexity,
+      title: store.state.title,
+      description: store.state.description,
+      category: store.state.category,
+      complexity: store.state.complexity,
     }
     console.log(attempt);
     await historyStore.createAttempt(attempt);
+  }
+
+  // This callback only runs upon a successful DELETE from the Sessions collection
+  const leaveSessionCallback = async() => {
+    //Save Attempt To History
+    await createAttempt();
+
     // Remove roomId & sessionLanguage from localStorage
     localStorage.removeItem("roomId");
     localStorage.removeItem("sessionLanguage");
@@ -169,7 +174,8 @@ export const ViewSession = observer(() => {
     modalComponentStore.setClosable(false);
   }
 
-  const changeQuestionCallback = () => {
+  const changeQuestionCallback = async () => {
+    await createAttempt();
     navigate(0);
   }
 

--- a/client/src/services/matchingService.js
+++ b/client/src/services/matchingService.js
@@ -42,7 +42,7 @@ const setupSocket = (onMatchSuccess, onMatchFailure, onMatchCancel, onSocketDisc
     const { roomId, firstUserId, secondUserId, complexity } = sessionCreationRequest;
 
     const question = await getRandomQuestionByComplexity(complexity);
-
+    
     const sessionDetails = {
       roomId,
       firstUserId,

--- a/client/src/services/questionService.js
+++ b/client/src/services/questionService.js
@@ -59,6 +59,21 @@ export const getRandomQuestionByComplexity = async (complexity) => {
   }
 }
 
+export const getFreshRandomQuestionByComplexity = async (complexity, currentId) => {
+  try {
+    const token = localStorage.getItem("jwt");
+    const res = await axios.get(`${basePath}/random?complexity=${complexity}&currentId=${currentId}`, {
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+    return res.data;
+  } catch (error) {
+    console.log("Error getting questionId:", error.message);
+    return null;
+  }
+}
+
 export const updateQuestionById = async (id, req) => {
   const token = localStorage.getItem("jwt");
   const res = await axios.put(`${basePath}/${id}`, req, {

--- a/client/src/stores/viewSessionStore.js
+++ b/client/src/stores/viewSessionStore.js
@@ -24,6 +24,7 @@ class ViewSessionStore {
 
     roomId: "",
     language: "",
+    isGetNextQuestionLoading: false,
   };
 
   constructor() {
@@ -62,6 +63,13 @@ class ViewSessionStore {
     notifyPeerLanguageChange(this.socket, language.toLowerCase());
   }
 
+  setIsGetQuestionLoading(isLoading) {
+    console.log("i am inside qn loading");
+    console.log(isLoading);
+
+    this.state.isGetNextQuestionLoading = isLoading;
+  }
+
   initQuestionState(question) {
     const { questionId, title, description, category, complexity } = question;
     this.state = {
@@ -96,6 +104,12 @@ class ViewSessionStore {
     }
   }
 
+  rejectChangeQuestion() {
+    if (this.state.roomId) {
+      rejectNextQuestionRequest(this.socket);
+    }
+  }
+
   resetState() {
     this.state = {
       questionId: -1,
@@ -105,6 +119,7 @@ class ViewSessionStore {
       complexity: "",
       roomId: "",
       language: "",
+      isGetNextQuestionLoading: false,
     };
   }
 
@@ -139,9 +154,6 @@ class ViewSessionStore {
       onLeaveRoomCallback,
       () => {
         // code for onSocketDisconnect but not in use
-
-        // this.socket = null;
-        // this.resetState();
       },
       receiveRequestCallback,
       changeQuestionCallback,

--- a/src/collaboration-service/controllers/session-controller.js
+++ b/src/collaboration-service/controllers/session-controller.js
@@ -93,12 +93,10 @@ exports.deleteSession = async (req, res) => {
   }
 }
 
-exports.saveAttempt = async (req, res) => {
+exports.editSession = async (req, res) => {
   try {
     const roomId = req.params.roomId;
-    const { attempt } = req.body;
-    
-    console.log(req.body);
+    const { title, description, category } = req.body;
 
     const session = await Session.findOne({ roomId });
 
@@ -106,7 +104,9 @@ exports.saveAttempt = async (req, res) => {
       return res.status(404).json({ message: "Session not found" });
     }
 
-    session.attempt = attempt;
+    session.title = title;
+    session.description = description;
+    session.category = category;
 
     await session.validate();
     await session.save();
@@ -114,7 +114,7 @@ exports.saveAttempt = async (req, res) => {
     return res.status(200).json(session);
   } catch (err) {
     console.log(err);
-    return res.status(500).json({ message: "Error saving attempt" });
+    return res.status(500).json({ message: "Error editing session details" });
   }
 }
 

--- a/src/collaboration-service/index.js
+++ b/src/collaboration-service/index.js
@@ -36,6 +36,14 @@ io.on("connection", (socket) => {
     socket.broadcast.emit("change-language", language);
   });
 
+  socket.on("initiate-next-question", () => {
+    socket.broadcast.emit("initiate-next-question");
+  })
+
+  socket.on("retrieve-next-question", () => {
+    socket.broadcast.emit("retrieve-next-question");
+  })
+
   socket.on("leave-room", () => {
     socket.broadcast.emit("leave-room");
   });
@@ -64,7 +72,7 @@ mongoose.connect(databaseUrl, {
 
 app.post("/api/session", sessionController.createSession);
 app.get("/api/session/:roomId", sessionController.getSession);
-app.put("/api/session/:roomId", sessionController.saveAttempt);
+app.put("/api/session/:roomId", sessionController.editSession);
 app.delete("/api/session/:roomId", sessionController.deleteSession);
 
 

--- a/src/collaboration-service/index.js
+++ b/src/collaboration-service/index.js
@@ -40,6 +40,10 @@ io.on("connection", (socket) => {
     socket.broadcast.emit("initiate-next-question");
   })
 
+  socket.on("reject-next-question", () => {
+    socket.broadcast.emit("reject-next-question");
+  });
+
   socket.on("retrieve-next-question", () => {
     socket.broadcast.emit("retrieve-next-question");
   })

--- a/src/question-service/src/controllers/question-controller.js
+++ b/src/question-service/src/controllers/question-controller.js
@@ -123,6 +123,9 @@ exports.getRandomQuestion = async (req, res) => {
         { $match: { questionId: { $ne: idNum }, complexity} },
         { $sample: { size: 1 } },
       ])
+
+      // If no question is found, return the current question.
+      randomQuestion[0] = randomQuestion.length === 1 ? randomQuestion[0] : await Question.find({ questionId: idNum });
     }
 
     return randomQuestion.length === 1

--- a/src/question-service/src/controllers/question-controller.js
+++ b/src/question-service/src/controllers/question-controller.js
@@ -125,8 +125,8 @@ exports.getRandomQuestion = async (req, res) => {
       ])
     }
 
-    return randomQuestion
-      ? res.status(200).json(randomQuestion)
+    return randomQuestion.length === 1
+      ? res.status(200).json(randomQuestion[0])
       : res.status(404).json({ message: "Question not found" });
   } catch (err) {
     console.log(err);


### PR DESCRIPTION
Functionality changes
- User can initiate a change question request
- Other use can accept or decline the change question request
- Accepting causes a page refresh for both, while declining resumes the current session
- Question will be changed to another question in the same category, or it will remain the same if it is the only question in the category.

Implementation Changes
- Collab service now have an edit session details to change the question
- Question service now take in an optional parameter to indicate the current question id
- Defined socket events for initiate request, accept request and decline request.

Closes #37 